### PR TITLE
Removed usage of `long`, added __init__.py module imports

### DIFF
--- a/build/lib/pybst/avltree.py
+++ b/build/lib/pybst/avltree.py
@@ -136,7 +136,7 @@ class AVLTree(BSTree):
         a new Node with key attribute key and value attribute
         value into T. Balances if necessary.
         """
-        if not isinstance(key,(int,long,float)):
+        if not isinstance(key,(int,float)):
             raise TypeError(str(key) + " is not a number")
         else:
             if not self.Root:

--- a/build/lib/pybst/bstree.py
+++ b/build/lib/pybst/bstree.py
@@ -193,7 +193,7 @@ class BSTree:
         a new Node with key attribute key and value attribute
         value into T.
         """
-        if not isinstance(key,(int,long,float)):
+        if not isinstance(key,(int,float)):
             raise TypeError(str(key) + " is not a number")
         else:
             if not self.Root:

--- a/build/lib/pybst/rbtree.py
+++ b/build/lib/pybst/rbtree.py
@@ -343,7 +343,7 @@ class RBTree(BSTree):
         Note: For more information on the cases to be considered for insertion,
         see: http://en.wikipedia.org/wiki/Red-black_tree
         """
-        if not isinstance(key,(int,long,float)):
+        if not isinstance(key,(int,float)):
             raise TypeError(str(key) + " is not a number")
         else:
             if not self.Root:

--- a/build/lib/pybst/splaytree.py
+++ b/build/lib/pybst/splaytree.py
@@ -145,7 +145,7 @@ class SplayTree(BSTree):
         a new Node with key attribute key and value attribute
         value into T and _rotates it to the root of T.
         """
-        if not isinstance(key,(int,long,float)):
+        if not isinstance(key,(int,float)):
             raise TypeError(str(key) + " is not a number")
         else:
             if not self.Root:

--- a/pybst/__init__.py
+++ b/pybst/__init__.py
@@ -1,1 +1,3 @@
+from pybst.avltree import *
+from pybst.bstree import *
 

--- a/pybst/avltree.py
+++ b/pybst/avltree.py
@@ -17,7 +17,7 @@
 # along with PyBST.  If not, see <http://www.gnu.org/licenses/>.
 
 import collections
-import bstree
+import pybst.bstree as bstree
 
 Node = bstree.Node
 BSTree = bstree.BSTree
@@ -136,7 +136,7 @@ class AVLTree(BSTree):
         a new Node with key attribute key and value attribute
         value into T. Balances if necessary.
         """
-        if not isinstance(key,(int,long,float)):
+        if not isinstance(key,(int,float)):
             raise TypeError(str(key) + " is not a number")
         else:
             if not self.Root:

--- a/pybst/bstree.py
+++ b/pybst/bstree.py
@@ -193,7 +193,7 @@ class BSTree:
         a new Node with key attribute key and value attribute
         value into T.
         """
-        if not isinstance(key,(int,long,float)):
+        if not isinstance(key,(int,float)):
             raise TypeError(str(key) + " is not a number")
         else:
             if not self.Root:

--- a/pybst/rbtree.py
+++ b/pybst/rbtree.py
@@ -343,7 +343,7 @@ class RBTree(BSTree):
         Note: For more information on the cases to be considered for insertion,
         see: http://en.wikipedia.org/wiki/Red-black_tree
         """
-        if not isinstance(key,(int,long,float)):
+        if not isinstance(key,(int,float)):
             raise TypeError(str(key) + " is not a number")
         else:
             if not self.Root:

--- a/pybst/splaytree.py
+++ b/pybst/splaytree.py
@@ -145,7 +145,7 @@ class SplayTree(BSTree):
         a new Node with key attribute key and value attribute
         value into T and _rotates it to the root of T.
         """
-        if not isinstance(key,(int,long,float)):
+        if not isinstance(key,(int,float)):
             raise TypeError(str(key) + " is not a number")
         else:
             if not self.Root:


### PR DESCRIPTION
Currently, installing this module in pip is somewhat useless because you cannot import any of the provided modules.

This PR introduces changes to the `pybst/__init__.py` file which includes importing the `avltree` module and the `bstree` module (other modules could be imported, but these were the two that I found most useful to expose atm).

In addition, this PR removes all references to the `long` data type which is a Python 2 artifact. This breaks Python 2 compatibility but makes the module compatible with Python 3 which is probably more relevant today. I believe another PR should be opened to separate Python 2 and Python 3 compatibility.